### PR TITLE
Uranium Fix

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -388,13 +388,13 @@ var/list/mining_floors = list()
 				for(var/i=0, i<quantity, i++)
 					new /obj/item/weapon/material/shard/phoron(src)
 
-			if(7)
-				var/obj/item/stack/material/uranium/R = new(src)
-				R.amount = rand(5,25)
+			//if(7)
+			//	var/obj/item/stack/material/uranium/R = new(src)
+			//	R.amount = rand(5,25)
 
 /turf/simulated/mineral/random
 	name = "Mineral deposit"
-	var/mineralSpawnChanceList = list("Uranium" = 5, "Platinum" = 5, "Iron" = 35, "Carbon" = 35, "Diamond" = 1, "Gold" = 5, "Silver" = 5, "Phoron" = 10)
+	var/mineralSpawnChanceList = list("Uranium" = 0, "Platinum" = 5, "Iron" = 35, "Carbon" = 35, "Diamond" = 1, "Gold" = 5, "Silver" = 5, "Phoron" = 10)
 	var/mineralChance = 100 //10 //means 10% chance of this plot changing to a mineral deposit
 
 /turf/simulated/mineral/random/New()
@@ -409,7 +409,7 @@ var/list/mining_floors = list()
 
 /turf/simulated/mineral/random/high_chance
 	mineralChance = 100 //25
-	mineralSpawnChanceList = list("Uranium" = 10, "Platinum" = 10, "Iron" = 60, "Carbon" = 20, "Diamond" = 2, "Gold" = 10, "Silver" = 10)
+	mineralSpawnChanceList = list("Uranium" = 0, "Platinum" = 10, "Iron" = 60, "Carbon" = 20, "Diamond" = 2, "Gold" = 10, "Silver" = 10)
 
 
 /**********************Asteroid**************************/


### PR DESCRIPTION
Removes Uranium Sheets from spawning due to the destruction of an artifact, Basically just removes uranium as a drop for the time being. Its not used anyway.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
